### PR TITLE
Kamereon initialisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,15 @@ pyze status
 ```python
 from pyze.api import Gigya, Kamereon, Vehicle
 
-g = Gigya()
-g.login('email', 'password')  # You should only need to do this once
+c = CredentialStore()
 
-k = Kamereon(g)  # Gigya argument is optional - if not supplied it will create one
+g = Gigya(c)
+g.login('email', 'password')
+g.account_info()
 
-v = Vehicle('YOUR_VIN', k)  # Kamereon argument is likewise optional
+k = Kamereon(c, g)
+
+v = Vehicle('YOUR_VIN', k)
 
 v.battery_status()
 ```

--- a/src/pyze/api/kamereon.py
+++ b/src/pyze/api/kamereon.py
@@ -28,7 +28,7 @@ class CachingAPIObject(object):
 
 
 class Kamereon(CachingAPIObject):
-    def __init__(self, credentials=CredentialStore(), country='GB'):
+    def __init__(self, credentials=CredentialStore(), gigya=None, country='GB'):
         self._api_key = os.environ.get('KAMEREON_API_KEY')
 
         if not self._api_key:
@@ -36,7 +36,10 @@ class Kamereon(CachingAPIObject):
 
         self._credentials = credentials
         self._country = country
-        self._gigya = Gigya(self._credentials)
+        if gigya is None:
+            self._gigya = Gigya(self._credentials)
+        else:
+            self._gigya = gigya
         self._session = requests.Session()
 
     @requires_credentials('gigya', 'gigya-person-id')


### PR DESCRIPTION
Contrary to the documentation, it is not possible currently to pass the Gigya instance to the Kamereon `__init__` initialisation method.

Also, both `login `and `account_info` methods need to be called on the Gigya instance before make a call to Kamereon or it triggers a `MissingCredentialException `