### PR TITLE
Extra tweaks for the Gigya and Kamereon root urls

### DIFF
--- a/src/pyze/api/gigya.py
+++ b/src/pyze/api/gigya.py
@@ -6,7 +6,7 @@ import os
 import requests
 
 
-DEFAULT_ROOT_URL = 'https://accounts.eu1.gigya.com/'
+DEFAULT_ROOT_URL = 'https://accounts.eu1.gigya.com'
 
 
 class Gigya(object):
@@ -30,7 +30,7 @@ class Gigya(object):
             raise RuntimeError('Gigya API key not specified. Call set_api_key or set GIGYA_API_KEY environment variable.')
 
         response = self._session.post(
-            self._root_url + 'accounts.login',
+            self._root_url + '/accounts.login',
             data={
                 'ApiKey': self._credentials['gigya-api-key'],
                 'loginID': user,
@@ -57,7 +57,7 @@ class Gigya(object):
     @requires_credentials('gigya')
     def account_info(self):
         response = self._session.post(
-            self._root_url + 'accounts.getAccountInfo',
+            self._root_url + '/accounts.getAccountInfo',
             {
                 'oauth_token': self._credentials['gigya']
             }
@@ -81,7 +81,7 @@ class Gigya(object):
             return self._credentials['gigya-token']
 
         response = self._session.post(
-            self._root_url + 'accounts.getJWT',
+            self._root_url + '/accounts.getJWT',
             {
                 'oauth_token': self._credentials['gigya'],
                 'fields': 'data.personId,data.gigyaDataCenter',

--- a/src/pyze/api/kamereon.py
+++ b/src/pyze/api/kamereon.py
@@ -12,7 +12,7 @@ import requests
 import json
 
 
-DEFAULT_ROOT_URL = 'https://api-wired-prod-1-euw1.wrd-aws.com/commerce/v1'
+DEFAULT_ROOT_URL = 'https://api-wired-prod-1-euw1.wrd-aws.com'
 
 
 class AccountException(Exception):
@@ -54,7 +54,7 @@ class Kamereon(CachingAPIObject):
             return self._credentials['kamereon-account']
 
         response = self._session.get(
-            '{}/persons/{}?country={}'.format(
+            '{}/commerce/v1/persons/{}?country={}'.format(
                 self._root_url,
                 self._credentials['gigya-person-id'],
                 self._country
@@ -85,7 +85,7 @@ class Kamereon(CachingAPIObject):
             return self._credentials['kamereon']
 
         response = self._session.get(
-            '{}/accounts/{}/kamereon/token?country={}'.format(
+            '{}/commerce/v1/accounts/{}/kamereon/token?country={}'.format(
                 self._root_url,
                 self.get_account_id(),
                 self._country
@@ -112,7 +112,7 @@ class Kamereon(CachingAPIObject):
     @requires_credentials('kamereon-api-key')
     def get_vehicles(self):
         response = self._session.get(
-            '{}/accounts/{}/vehicles?country={}'.format(
+            '{}/commerce/v1/accounts/{}/vehicles?country={}'.format(
                 self._root_url,
                 self.get_account_id(),
                 self._country
@@ -153,7 +153,7 @@ class Vehicle(object):
     def _get(self, endpoint):
         response = self._request(
             'GET',
-            '{}/accounts/kmr/remote-services/car-adapter/v1/cars/{}/{}'.format(
+            '{}/commerce/v1/accounts/kmr/remote-services/car-adapter/v1/cars/{}/{}'.format(
                 self._root_url,
                 self._vin,
                 endpoint
@@ -166,7 +166,7 @@ class Vehicle(object):
     def _post(self, endpoint, data):
         response = self._request(
             'POST',
-            '{}/accounts/kmr/remote-services/car-adapter/v1/cars/{}/{}'.format(
+            '{}/commerce/v1/accounts/kmr/remote-services/car-adapter/v1/cars/{}/{}'.format(
                 self._root_url,
                 self._vin,
                 endpoint


### PR DESCRIPTION
Extra tweaks for #1 regarding the root url, to keep in line with the configuration files provided by Renault on AWS (sample file is available on https://renault-wrd-prod-1-euw1-myrapp-one.s3-eu-west-1.amazonaws.com/configuration/android/config_fr-FR.json).