### PR TITLE
Go back to using simplejson

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
         'pyjwt',
         'python-dateutil',
         'requests',
+        'simplejson',
         'tabulate'
     ],
     setup_requires=[

--- a/src/pyze/api/credentials.py
+++ b/src/pyze/api/credentials.py
@@ -1,8 +1,8 @@
 from collections import namedtuple
 
 import os
+import simplejson
 import time
-import json
 
 
 TOKEN_STORE = os.environ.get('PYZE_TOKEN_STORE', os.path.expanduser('~/.credentials/pyze.json'))
@@ -28,7 +28,7 @@ def init_store():
     new_store = {}
     try:
         with open(TOKEN_STORE, 'r') as token_store:
-            stored = json.load(token_store)
+            stored = simplejson.load(token_store)
 
             for key, value in stored.items():
                 new_store[key] = Credential(*value)
@@ -74,7 +74,7 @@ class CredentialStore(object):
             if not os.path.isdir(dirname):
                 os.makedirs(dirname)
             with open(TOKEN_STORE, 'w') as token_store:
-                json.dump(self._store, token_store)
+                simplejson.dump(self._store, token_store)
 
         def __contains__(self, name):
             try:

--- a/src/pyze/api/kamereon.py
+++ b/src/pyze/api/kamereon.py
@@ -9,7 +9,7 @@ import dateutil.tz
 import jwt
 import os
 import requests
-import json
+import simplejson
 
 
 DEFAULT_ROOT_URL = 'https://api-wired-prod-1-euw1.wrd-aws.com'
@@ -320,7 +320,7 @@ class Vehicle(object):
 
         return self._post(
             'actions/charge-schedule',
-            json.loads(json.dumps(data, for_json=True))
+            simplejson.loads(simplejson.dumps(data, for_json=True))
         )
 
     def set_charge_mode(self, charge_mode):


### PR DESCRIPTION
This reverts the changes made in #4, because python3's built-in `json` is an older fork of `simplejson` and does not support our use case (specifically, the use of `for_json`).