### PR TITLE
Handle various possible error reponses when collating data.

### DIFF
--- a/src/pyze/cli/status.py
+++ b/src/pyze/cli/status.py
@@ -1,8 +1,10 @@
 from .common import add_vehicle_args, format_duration_minutes, get_vehicle
 from tabulate import tabulate
 
+import collections
 import dateutil.parser
 import dateutil.tz
+import requests
 
 
 KM_PER_MILE = 1.609344
@@ -15,26 +17,49 @@ def configure_parser(parser):
     parser.add_argument('--km', help='Give distances in kilometers (default is miles)', action='store_true')
 
 
+def wrap_unavailable(obj, method):
+    try:
+        return getattr(obj, method)()
+    except requests.RequestException:
+        dummy = collections.defaultdict(lambda: 'Unavailable')
+        dummy['_unavailable'] = True
+        return dummy
+
+
 def run(parsed_args):
     v = get_vehicle(parsed_args)
 
-    status = v.battery_status()
+    status = wrap_unavailable(v, 'battery_status')
     # {'lastUpdateTime': '2019-07-12T00:38:01Z', 'chargePower': 2, 'instantaneousPower': 6600, 'plugStatus': 1, 'chargeStatus': 1, 'batteryLevel': 28, 'rangeHvacOff': 64, 'timeRequiredToFullSlow': 295}
-    plugged_in, charging = status['plugStatus'] > 0, status['chargeStatus'] > 0
-    charge_mode = v.charge_mode()
-
-    hvac = v.hvac_status()
-
-    mileage = v.mileage()['totalMileage']
-
-    if parsed_args.km:
-        range_text = '{:.1f} km'.format(status['rangeHvacOff'])
-        mileage_text = "{:.1f} km".format(mileage)
+    if status.get('_unavailable', False):
+        plugged_in, charging = False, False
+        range_text = status['rangeHvacOff']
     else:
-        range_text = '{:.1f} miles'.format(status['rangeHvacOff'] / KM_PER_MILE)
-        mileage_text = "{:.1f} mi".format(mileage / KM_PER_MILE)
+        plugged_in, charging = status['plugStatus'] > 0, status['chargeStatus'] > 0
+        if parsed_args.km:
+            range_text = '{:.1f} km'.format(status['rangeHvacOff'])
+        else:
+            range_text = '{:.1f} miles'.format(status['rangeHvacOff'] / KM_PER_MILE)
 
-    if 'nextHvacStartDate' in hvac:
+    try:
+        charge_mode = v.charge_mode()
+    except requests.RequestException:
+        charge_mode = 'Unavailable'
+
+    mileage = wrap_unavailable(v, 'mileage')
+    if mileage.get('_unavailable', False):
+        mileage_text = mileage['totalMileage']
+    else:
+        if parsed_args.km:
+            mileage_text = "{:.1f} km".format(mileage['totalMileage'])
+        else:
+            mileage_text = "{:.1f} mi".format(mileage['totalMileage'] / KM_PER_MILE)
+
+    hvac = wrap_unavailable(v, 'hvac_status')
+    if hvac.get('_unavailable', False):
+        hvac_start = hvac['nextHvacStartDate']
+        external_temp = hvac['externalTemperature']
+    elif 'nextHvacStartDate' in hvac:
         hvac_start = dateutil.parser.parse(
             hvac['nextHvacStartDate']
         ).astimezone(
@@ -42,16 +67,21 @@ def run(parsed_args):
         ).strftime(
             '%Y-%m-%d %H:%M:%S'
         )
+        external_temp = "{}°C".format(hvac['externalTemperature'])
     else:
         hvac_start = None
+        external_temp = "{}°C".format(hvac['externalTemperature'])
 
-    update_time = dateutil.parser.parse(
-        status['lastUpdateTime']
-    ).astimezone(
-        dateutil.tz.tzlocal()
-    ).strftime(
-        '%Y-%m-%d %H:%M:%S'
-    )
+    try:
+        update_time = dateutil.parser.parse(
+            status['lastUpdateTime']
+        ).astimezone(
+            dateutil.tz.tzlocal()
+        ).strftime(
+            '%Y-%m-%d %H:%M:%S'
+        )
+    except ValueError:
+        update_time = status['lastUpdateTime']
 
     vehicle_table = [
         ["Battery level", "{}%".format(status['batteryLevel'])],
@@ -61,9 +91,9 @@ def run(parsed_args):
         ['Charge rate', "{:.2f}kW".format(status['instantaneousPower'] / 1000)] if 'instantaneousPower' in status else None,
         ['Time remaining', format_duration_minutes(status['timeRequiredToFullSlow'])[:-3]] if 'timeRequiredToFullSlow' in status else None,
         ['Charge mode', charge_mode.value if hasattr(charge_mode, 'value') else charge_mode],
-        ['AC state', hvac['hvacStatus'] if 'hvacStatus' in hvac else None],
+        ['AC state', hvac['hvacStatus']] if 'hvacStatus' in hvac else None,
         ['AC start at', hvac_start] if hvac_start else None,
-        ['External temperature', "{}°C".format(hvac['externalTemperature'])],
+        ['External temperature', external_temp],
         ['Battery temperature', "{}°C".format(status['batteryTemperature'])] if 'batteryTemperature' in status else None,
         ['Total mileage', mileage_text],
         ['Updated at', update_time]

--- a/src/pyze/cli/status.py
+++ b/src/pyze/cli/status.py
@@ -38,7 +38,7 @@ def run(parsed_args):
         plugged_in, charging = False, False
         range_text = status['rangeHvacOff']
     else:
-        plugged_in, charging = status['plugStatus'] > 0, status['chargeStatus'] > 0
+        plugged_in, charging = status.get('plugStatus', 0) > 0, status.get('chargeStatus', 0) > 0
         if 'rangeHvacOff' in status:
             if parsed_args.km:
                 range_text = '{:.1f} km'.format(status['rangeHvacOff'])


### PR DESCRIPTION
This PR allows the `pyze status` command to handle error responses from the API endpoints it calls and still try to return useful information to the user.

If an API call results in an error, it will handle the exception and list "unavailable" for the relevant data item.

This is necessary because Renault's API is flaky enough that any call might fail for no particular reason on any particular attempt - see #24 - and because some people only have one of the two ZE Services subscriptions meaning some endpoints are unavailable to them  - see #20.

I've not extended this approach to other commands since they all operate with a single API call - so it's either all or nothing, whereas here we might still be able to display useful information.

Fixes #20. Fixes #24.