### PR TITLE
Handle `totalMileage` being missing from its API response.

### DIFF
--- a/src/pyze/cli/status.py
+++ b/src/pyze/cli/status.py
@@ -53,7 +53,7 @@ def run(parsed_args):
         charge_mode = 'Unavailable'
 
     mileage = wrap_unavailable(v, 'mileage')
-    if mileage.get('_unavailable', False):
+    if mileage.get('_unavailable', False) or 'totalMileage' not in mileage:
         mileage_text = mileage['totalMileage']
     else:
         if parsed_args.km:


### PR DESCRIPTION
Literally, it's the only thing that API endpoint has to return... :man_facepalming: 

Fixes #37.