### PR TITLE
Implement "phase two" functionality

### DIFF
--- a/.github/workflows/pyze_test.yml
+++ b/.github/workflows/pyze_test.yml
@@ -25,4 +25,21 @@ jobs:
         pycodestyle src/
     - name: Run pytest
       run: |
-        python setup.py pytest
+        python setup.py pytest --addopts "--junitxml=test-results.xml --cov=pyze --cov-report=xml --cov-report=html"
+    - name: Upload test results
+      uses: actions/upload-artifact@master
+      with:
+        name: pytest-results
+        path: test-results.xml
+      # Use always() to always run this step to publish test results when there are test failures
+      if: always()
+    - name: Upload HTML coverage results
+      uses: actions/upload-artifact@master
+      with:
+        name: coverage
+        path: htmlcov
+    - name: Upload XML coverage results
+      uses: actions/upload-artifact@master
+      with:
+        name: coverage-xml
+        path: coverage.xml

--- a/.github/workflows/pyze_test.yml
+++ b/.github/workflows/pyze_test.yml
@@ -23,4 +23,6 @@ jobs:
       run: |
         pip install pycodestyle
         pycodestyle src/
-
+    - name: Run pytest
+      run: |
+        python setup.py pytest

--- a/.github/workflows/pyze_test.yml
+++ b/.github/workflows/pyze_test.yml
@@ -25,7 +25,7 @@ jobs:
         pycodestyle src/
     - name: Run pytest
       run: |
-        python setup.py pytest --addopts "--junitxml=test-results.xml --cov=pyze --cov-report=xml --cov-report=html"
+        python setup.py pytest --addopts "--junitxml=test-results.xml --cov=pyze --cov-report=xml"
     - name: Upload test results
       uses: actions/upload-artifact@master
       with:
@@ -33,13 +33,15 @@ jobs:
         path: test-results.xml
       # Use always() to always run this step to publish test results when there are test failures
       if: always()
-    - name: Upload HTML coverage results
-      uses: actions/upload-artifact@master
-      with:
-        name: coverage
-        path: htmlcov
     - name: Upload XML coverage results
       uses: actions/upload-artifact@master
       with:
         name: coverage-xml
         path: coverage.xml
+    - name: Upload coverage to Coveralls
+      env:
+        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        CI_BRANCH: ${GITHUB_REF#"ref/heads"}
+      run: |
+        pip install coveralls
+        coveralls

--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,11 @@ pip-log.txt
 
 # Unit test / coverage reports
 .coverage
+coverage.xml
 .tox
 nosetests.xml
+test-results*.xml
+htmlcov/
 
 # Translations
 *.mo

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [pycodestyle]
 ignore = E501
+
+[tool:pytest]
+junit_family=xunit2

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ setup(
         'pytest-runner',
     ],
     tests_require=[
-        'pytest'
+        'pytest',
+        'pytest-cov'
     ],
     entry_points={
         'console_scripts': [

--- a/src/pyze/api/__init__.py
+++ b/src/pyze/api/__init__.py
@@ -1,4 +1,4 @@
 from .credentials import CredentialStore, requires_credentials
 from .gigya import Gigya
-from .kamereon import Kamereon, Vehicle, ChargeState
+from .kamereon import Kamereon, Vehicle, ChargeState, PlugState
 from .schedule import ChargeSchedule, ScheduledCharge, ChargeMode

--- a/src/pyze/api/__init__.py
+++ b/src/pyze/api/__init__.py
@@ -1,4 +1,4 @@
 from .credentials import CredentialStore, requires_credentials
 from .gigya import Gigya
-from .kamereon import Kamereon, Vehicle
+from .kamereon import Kamereon, Vehicle, ChargeState
 from .schedule import ChargeSchedule, ScheduledCharge, ChargeMode

--- a/src/pyze/api/__tests__/test_schedule.py
+++ b/src/pyze/api/__tests__/test_schedule.py
@@ -1,0 +1,64 @@
+from pyze.api.schedule import ChargeSchedules, _minuteize, _deminuteize
+
+
+def test_parse_schedules():
+    raw_schedules = {
+        "mode": "scheduled",
+        "schedules": [{
+            "id": 1,
+            "activated": True,
+            "monday": {
+                "startTime": "T12:00Z",
+                "duration": 15
+            },
+            "tuesday": {
+                "startTime": "T04:30Z",
+                "duration": 420
+            },
+            "wednesday": {
+                "startTime": "T22:30Z",
+                "duration": 420
+            },
+            "thursday": {
+                "startTime": "T22:00Z",
+                "duration": 420
+            },
+            "friday": {
+                "startTime": "T12:15Z",
+                "duration": 15
+            },
+            "saturday": {
+                "startTime": "T12:30Z",
+                "duration": 30
+            },
+            "sunday": {
+                "startTime": "T12:45Z",
+                "duration": 45
+            }
+        }]
+    }
+
+    schedules = ChargeSchedules(raw_schedules)
+
+    assert len(schedules) == 1
+    schedule = schedules[1]
+
+    assert schedule['monday'].start_time == 'T12:00Z'
+    assert schedule['monday'].duration == 15
+
+    assert schedule['wednesday'].start_time == 'T22:30Z'
+    assert schedule['wednesday'].duration == 420
+
+
+def test_minuteize():
+    assert _minuteize('T00:00Z') == 0
+    assert _minuteize('T01:00Z') == 60
+    assert _minuteize('T12:00Z') == (12 * 60)
+    assert _minuteize('T23:59Z') == (24 * 60) - 1
+
+
+def test_deminuteize():
+    assert _deminuteize(0) == 'T00:00Z'
+    assert _deminuteize(60) == 'T01:00Z'
+    assert _deminuteize(12 * 60) == 'T12:00Z'
+    assert _deminuteize((24 * 60) - 1) == 'T23:59Z'

--- a/src/pyze/api/__tests__/test_schedule.py
+++ b/src/pyze/api/__tests__/test_schedule.py
@@ -109,3 +109,23 @@ class TestScheduledCharge:
             ScheduledCharge('T12:00Z', -1).validate()
         with pytest.raises(InvalidScheduleException, match=r".*not a valid duration.*"):
             ScheduledCharge('T12:00Z', '15').validate()
+
+
+class TestCreatingFromNew():
+    def test_create_schedules(self):
+        cs = ChargeSchedules()
+        assert len(cs) == 0
+
+    def test_create_schedule(self):
+        cs = ChargeSchedules()
+
+        sch = cs.new_schedule()
+        assert sch.id == 1
+        assert sch['monday'].start_time == 'T12:00Z'
+        assert sch['wednesday'].duration == 15
+
+        assert sch.validate() is True
+        assert cs.validate() is True
+
+        sch2 = cs.new_schedule()
+        assert sch2.id == 2

--- a/src/pyze/api/kamereon.py
+++ b/src/pyze/api/kamereon.py
@@ -177,14 +177,18 @@ class Vehicle(object):
                 'x-gigya-id_token': self._kamereon._gigya.get_jwt_token(),
                 'x-kamereon-authorization': 'Bearer {}'.format(self._kamereon.get_token())
             },
+            params={
+                'country': self._kamereon._country
+            },
             **kwargs
         )
 
     def _get(self, endpoint, version=1):
         response = self._request(
             'GET',
-            '{}/commerce/v1/accounts/kmr/remote-services/car-adapter/v{}/cars/{}/{}'.format(
+            '{}/commerce/v1/accounts/{}/kamereon/kca/car-adapter/v{}/cars/{}/{}'.format(
                 self._root_url,
+                self._kamereon.get_account_id(),
                 version,
                 self._vin,
                 endpoint
@@ -200,8 +204,9 @@ class Vehicle(object):
         _log.debug('POSTing with data: {}'.format(data))
         response = self._request(
             'POST',
-            '{}/commerce/v1/accounts/kmr/remote-services/car-adapter/v{}/cars/{}/{}'.format(
+            '{}/commerce/v1/accounts/{}/kamereon/kca/car-adapter/v{}/cars/{}/{}'.format(
                 self._root_url,
+                self._kamereon.get_account_id(),
                 version,
                 self._vin,
                 endpoint

--- a/src/pyze/api/kamereon.py
+++ b/src/pyze/api/kamereon.py
@@ -396,7 +396,10 @@ _CHARGE_STATES = {
     0.3: ['Waiting for current charge', 'WAITING_FOR_CURRENT_CHARGE'],
     0.4: ['Energy flap opened', 'ENERGY_FLAP_OPENED'],
     1.0: ['Charging', 'CHARGE_IN_PROGRESS'],
-    -1.0: ['Not plugged in', 'CHARGE_ERROR'],
+    # This next is more accurately "not charging" (<= ZE40) or "error" (ZE50).
+    # But I don't want to include 'error' in the output text because people will
+    # think that it's an error in Pyze when their ZE40 isn't plugged in...
+    -1.0: ['Not charging or plugged in', 'CHARGE_ERROR'],
     -1.1: ['Not available', 'NOT_AVAILABLE']
 }
 
@@ -404,6 +407,20 @@ ChargeState = Enum(
     value='ChargeState',
     names=itertools.chain.from_iterable(
         itertools.product(v, [k]) for k, v in _CHARGE_STATES.items()
+    )
+)
+
+_PLUG_STATES = {
+    0: ['Unplugged', 'UNPLUGGED'],
+    1: ['Plugged in', 'PLUGGED'],
+    -1: ['Plug error', 'PLUG_ERROR'],
+    -2147483648: ['Not available', 'NOT_AVAILABLE']
+}
+
+PlugState = Enum(
+    value='PlugState',
+    names=itertools.chain.from_iterable(
+        itertools.product(v, [k]) for k, v in _PLUG_STATES.items()
     )
 )
 

--- a/src/pyze/api/kamereon.py
+++ b/src/pyze/api/kamereon.py
@@ -385,6 +385,17 @@ class Vehicle(object):
             data
         )
 
+    def charge_start(self):
+        return self._post(
+            'actions/charging-start',
+            {
+                'type': 'ChargingStart',
+                'attributes': {
+                    'action': 'start'
+                }
+            }
+        )
+
 # Serious metaprogramming follows:
 # https://www.notinventedhere.org/articles/python/how-to-use-strings-as-name-aliases-in-python-enums.html
 

--- a/src/pyze/api/kamereon.py
+++ b/src/pyze/api/kamereon.py
@@ -198,6 +198,7 @@ class Vehicle(object):
         )
 
         _log.debug('Received Kamereon vehicle response: {}'.format(response.text))
+        _log.debug('Response headers: {}'.format(response.headers))
         response.raise_for_status()
         json = response.json()
         return json['data']['attributes']
@@ -219,6 +220,7 @@ class Vehicle(object):
         )
 
         _log.debug('Received Kamereon vehicle response: {}'.format(response.text))
+        _log.debug('Response headers: {}'.format(response.headers))
         response.raise_for_status()
         json = response.json()
         return json

--- a/src/pyze/api/kamereon.py
+++ b/src/pyze/api/kamereon.py
@@ -1,6 +1,6 @@
 from .credentials import CredentialStore, requires_credentials, TOKEN_STORE
 from .gigya import Gigya
-from .schedule import ChargeSchedule, ChargeMode
+from .schedule import ChargeSchedules, ChargeMode
 from collections import namedtuple
 from enum import Enum
 from functools import lru_cache
@@ -249,9 +249,9 @@ class Vehicle(object):
     def location(self):
         return self._get('location')
 
-    def charge_schedule(self):
-        return ChargeSchedule(
-            self._get('charge-schedule')
+    def charge_schedules(self):
+        return ChargeSchedules(
+            self._get('charging-settings')
         )
 
     def notification_settings(self):
@@ -354,24 +354,25 @@ class Vehicle(object):
             }
         )
 
-    def set_charge_schedule(self, schedule):
-        if not isinstance(schedule, ChargeSchedule):
-            raise RuntimeError('Expected schedule to be instance of ChargeSchedule, but got {} instead'.format(schedule.__class__))
-        schedule.validate()
+    def set_charge_schedules(self, schedules):
+        if not isinstance(schedules, ChargeSchedules):
+            raise RuntimeError('Expected schedule to be instance of ChargeSchedules, but got {} instead'.format(schedule.__class__))
+        schedules.validate()
 
         data = {
             'type': 'ChargeSchedule',
-            'attributes': schedule
+            'attributes': schedules
         }
 
         return self._post(
             'actions/charge-schedule',
-            simplejson.loads(simplejson.dumps(data, for_json=True))
+            simplejson.loads(simplejson.dumps(data, for_json=True)),
+            version=2
         )
 
     def set_charge_mode(self, charge_mode):
         if not isinstance(charge_mode, ChargeMode):
-            raise RuntimeError('Expceted charge_mode to be instance of ChargeMode, but got {} instead'.format(charge_mode.__class__))
+            raise RuntimeError('Expected charge_mode to be instance of ChargeMode, but got {} instead'.format(charge_mode.__class__))
 
         data = {
             'type': 'ChargeMode',

--- a/src/pyze/api/schedule.py
+++ b/src/pyze/api/schedule.py
@@ -144,7 +144,7 @@ class ChargeSchedule(object):
             'activated': self.activated
         }
         for day in DAYS:
-            result[day] = self._schedule[day]
+            result[day] = self._schedule[day].for_json()
         return result
 
 
@@ -169,12 +169,15 @@ class ScheduledCharge(object):
         if start >= end:
             raise RuntimeError('Start time should be before end time.')
 
+        start_rounded = round_date_fifteen(start)
+        end_rounded = round_date_fifteen(end)
+
         start_string = 'T{:02g}:{:02g}Z'.format(
-            start.hour,
-            round_fifteen(start.minute)
+            start_rounded.hour,
+            start_rounded.minute
         )
 
-        duration = round_fifteen((end - start).total_seconds() // 60)
+        duration = round_fifteen((end_rounded - start_rounded).total_seconds() // 60)
 
         if duration < 15:
             raise RuntimeError('Duration must be at least 15 minutes')
@@ -256,3 +259,14 @@ def _deminuteize(tval):
 
 def round_fifteen(val):
     return (val // 15) * 15
+
+
+def round_date_fifteen(dt):
+    return datetime.datetime(
+        year=dt.year,
+        month=dt.month,
+        day=dt.day,
+        hour=dt.hour,
+        minute=round_fifteen(dt.minute),
+        second=0
+    )

--- a/src/pyze/cli/__main__.py
+++ b/src/pyze/cli/__main__.py
@@ -16,6 +16,7 @@ COMMAND_MODULES = [
     'ac-stats',
     'charge-history',
     'charge-mode',
+    'charge-start',
     'charge-stats',
     'login',
     'schedule',

--- a/src/pyze/cli/charge-start.py
+++ b/src/pyze/cli/charge-start.py
@@ -1,0 +1,16 @@
+from pyze.api import Kamereon, Vehicle
+from .common import add_vehicle_args, get_vehicle
+
+import dateparser
+
+
+help_text = 'Begin charging immediately (if your vehicle is plugged in).'
+
+
+def configure_parser(parser):
+    add_vehicle_args(parser)
+
+
+def run(parsed_args):
+    v = get_vehicle(parsed_args)
+    v.charge_start()

--- a/src/pyze/cli/status.py
+++ b/src/pyze/cli/status.py
@@ -1,4 +1,5 @@
 from .common import add_vehicle_args, format_duration_minutes, get_vehicle
+from pyze.api import ChargeState
 from tabulate import tabulate
 
 import collections
@@ -35,17 +36,24 @@ def run(parsed_args):
     status = wrap_unavailable(v, 'battery_status')
     # {'lastUpdateTime': '2019-07-12T00:38:01Z', 'chargePower': 2, 'instantaneousPower': 6600, 'plugStatus': 1, 'chargeStatus': 1, 'batteryLevel': 28, 'rangeHvacOff': 64, 'timeRequiredToFullSlow': 295}
     if status.get('_unavailable', False):
-        plugged_in, charging = False, False
+        plugged_in = False
+        charge_state = ChargeState.NOT_AVAILABLE
         range_text = status['rangeHvacOff']
     else:
-        plugged_in, charging = status.get('plugStatus', 0) > 0, status.get('chargeStatus', 0) > 0
-        if 'rangeHvacOff' in status:
+        plugged_in = status.get('plugStatus', 0) > 0
+
+        try:
+            charge_state = ChargeState(status.get('chargingStatus'))
+        except ValueError:
+            charge_state = ChargeState.NOT_AVAILABLE
+
+        if 'batteryAutonomy' in status:
             if parsed_args.km:
-                range_text = '{:.1f} km'.format(status['rangeHvacOff'])
+                range_text = '{:.1f} km'.format(status['batteryAutonomy'])
             else:
-                range_text = '{:.1f} miles'.format(status['rangeHvacOff'] / KM_PER_MILE)
+                range_text = '{:.1f} miles'.format(status['batteryAutonomy'] / KM_PER_MILE)
         else:
-            range_text = status['rangeHvacOff']  # Fall back to default value
+            range_text = status['batteryAutonomy']  # Fall back to default value
 
     try:
         charge_mode = v.charge_mode()
@@ -80,22 +88,23 @@ def run(parsed_args):
 
     try:
         update_time = dateutil.parser.parse(
-            status['lastUpdateTime']
+            status['timestamp']
         ).astimezone(
             dateutil.tz.tzlocal()
         ).strftime(
             '%Y-%m-%d %H:%M:%S'
         )
     except ValueError:
-        update_time = status['lastUpdateTime']
+        update_time = status['timestamp']
 
     vehicle_table = [
         ["Battery level", "{}%".format(status['batteryLevel'])],
+        ["Available energy", "{}kWh".format(status['batteryAvailableEnergy'])] if status.get('batteryAvailableEnergy', 0) > 0 else None,
         ["Range estimate", range_text],
         ['Plugged in', 'Yes' if plugged_in else 'No'],
-        ['Charging', 'Yes' if charging else 'No'],
-        ['Charge rate', "{:.2f}kW".format(status['instantaneousPower'] / 1000)] if 'instantaneousPower' in status else None,
-        ['Time remaining', format_duration_minutes(status['timeRequiredToFullSlow'])[:-3]] if 'timeRequiredToFullSlow' in status else None,
+        ['Charging state', charge_state.name],
+        ['Charge rate', "{:.2f}kW".format(status['chargingInstantaneousPower'] / 1000)] if 'chargingInstantaneousPower' in status else None,
+        ['Time remaining', format_duration_minutes(status['chargingRemainingTime'])[:-3]] if 'chargingRemainingTime' in status else None,
         ['Charge mode', charge_mode.value if hasattr(charge_mode, 'value') else charge_mode],
         ['AC state', hvac['hvacStatus']] if 'hvacStatus' in hvac else None,
         ['AC start at', hvac_start] if hvac_start else None,


### PR DESCRIPTION
This PR implements a number of "phase two" functions from the Renault API:

- "Start charging now" endpoint and CLI command. Resolves #29.
- Use v2 of the battery status endpoint. Resolves #28.
  - The `pyze status` command works in much the same way, but now uses structured values for charge/plug status. Sadly these values are inconsistent across <=ZE40 and ZE50.
- Use v2 of the charge scheduler endpoints. Resolves #27.
  - v2 of the "get schedule" endpoint is actually under `/v1` because Renault
  - `pyze schedule` behaves in almost exactly the same way, but now takes an optional `--id` parameter since the API theoretically supports multiple schedules. `pyze schedule show` without an ID will list all schedules.
- Use newer-style URLs that incorporate account IDs. Resolves #34.

It also integrates some unit tests for scheduler-related functions; it's about time we developed a more thorough test suite for the rest of pyze, too.