### PR TITLE
Allow charging schedules to have missing days.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@ ignore = E501
 
 [tool:pytest]
 junit_family=xunit2
+filterwarnings =
+    ignore
+    default:::pyze

--- a/src/pyze/api/__tests__/test_schedule.py
+++ b/src/pyze/api/__tests__/test_schedule.py
@@ -231,3 +231,9 @@ class TestChargeSchedule():
         expected = INITIAL_SCHEDULE.copy()
         expected['id'] = None
         assert cs.for_json() == expected
+
+        # New API allows days to have no scheduled charges
+        # see https://github.com/jamesremuscat/pyze/issues/46
+        del cs['monday']
+        del expected['monday']
+        assert cs.for_json() == expected

--- a/src/pyze/api/kamereon.py
+++ b/src/pyze/api/kamereon.py
@@ -245,7 +245,7 @@ class Vehicle(object):
     def lock_status(self):
         return self._get('lock-status')
 
-    # Not (currently) implemented server-side
+    # Not implemented server-side for most vehicles
     def location(self):
         return self._get('location')
 

--- a/src/pyze/api/schedule.py
+++ b/src/pyze/api/schedule.py
@@ -18,7 +18,11 @@ DAYS = [
 def _parse_schedule(data):
     schedule = {}
     for day in DAYS:
-        schedule[day] = ScheduledCharge(data[day]['startTime'], data[day]['duration'])
+        if day in data:
+            schedule[day] = ScheduledCharge(
+                data[day]['startTime'],
+                data[day]['duration']
+            )
 
     return data.get('id'), data.get('activated', False), schedule
 
@@ -110,8 +114,8 @@ class ChargeSchedule(object):
 
             if charge_time.spans_midnight:
                 next_day = DAYS[(DAYS.index(day) + 1) % len(DAYS)]
-                tomorrow_charge = self._schedule[next_day]
-                if charge_time.overlaps(tomorrow_charge):
+                tomorrow_charge = self._schedule.get(next_day)
+                if tomorrow_charge and charge_time.overlaps(tomorrow_charge):
                     raise InvalidScheduleException('Charge for {} overlaps charge for {}'.format(day, next_day))
         return True
 
@@ -129,6 +133,9 @@ class ChargeSchedule(object):
         # to make it valid (or else risk it being essentially immutable without gymnastics).
         self._schedule[key] = value
 
+    def __delitem__(self, key):
+        return self._schedule.__delitem__(key)
+
     def items(self):
         return self._schedule.items()
 
@@ -143,8 +150,8 @@ class ChargeSchedule(object):
             'id': self.id,
             'activated': self.activated
         }
-        for day in DAYS:
-            result[day] = self._schedule[day].for_json()
+        for day, schedule in self._schedule.items():
+            result[day] = schedule.for_json()
         return result
 
 

--- a/src/pyze/cli/__tests__/test_cli_schedule.py
+++ b/src/pyze/cli/__tests__/test_cli_schedule.py
@@ -1,0 +1,71 @@
+from collections import namedtuple
+from pyze.api.schedule import ChargeSchedules
+from pyze.cli.schedule import show
+
+
+def test_show(capsys):
+    valid_gappy_schedules = {
+        "mode": "always",
+        "schedules": [
+            {
+                "id": 1,
+                "activated": True,
+                "monday": {
+                    "startTime": "T23:30Z",
+                    "duration": 60
+                },
+                "thursday": {
+                    "startTime": "T01:00Z",
+                    "duration": 120
+                }
+            },
+            {
+                "id": 2,
+                "activated": False
+            },
+            {
+                "id": 3,
+                "activated": False
+            },
+            {
+                "id": 4,
+                "activated": False
+            },
+            {
+                "id": 5,
+                "activated": False
+            }
+        ]
+    }
+
+    cs = ChargeSchedules(valid_gappy_schedules)
+    show(cs, None, namedtuple('parsed_args', ['utc'])(False))
+
+    output = capsys.readouterr()
+
+    expected_out = '''
+Schedule ID: 1 [Active]
+Day       Start time    End time    Duration
+--------  ------------  ----------  ----------
+Monday    23:30         00:30+      1:00:00
+Thursday  01:00         03:00       2:00:00
+
+Schedule ID: 2
+Day    Start time    End time    Duration
+-----  ------------  ----------  ----------
+
+Schedule ID: 3
+Day    Start time    End time    Duration
+-----  ------------  ----------  ----------
+
+Schedule ID: 4
+Day    Start time    End time    Duration
+-----  ------------  ----------  ----------
+
+Schedule ID: 5
+Day    Start time    End time    Duration
+-----  ------------  ----------  ----------
+
+'''.strip()
+
+    assert output.out.strip() == expected_out

--- a/src/pyze/cli/schedule.py
+++ b/src/pyze/cli/schedule.py
@@ -91,6 +91,7 @@ def print_schedule(s, use_utc):
             headers=['Day', 'Start time', 'End time', 'Duration']
         )
     )
+    print()
 
 
 def format_schedule(s, use_utc):


### PR DESCRIPTION
The latest incarnation of the API allows charge schedules to omit days.

This PR allows pyze to cope with that.

Fixes #46.