### PR TITLE
Use v2 of the `cockpit` endpoint.

### DIFF
--- a/src/pyze/api/kamereon.py
+++ b/src/pyze/api/kamereon.py
@@ -242,7 +242,7 @@ class Vehicle(object):
             return raw_mode
 
     def mileage(self):
-        return self._get('cockpit')
+        return self._get('cockpit', 2)
 
     # Not (currently) implemented server-side
     def lock_status(self):


### PR DESCRIPTION
Resolves #50.