### PR TITLE
Don't verify "not before" date of issued Kamereon token.

### DIFF
--- a/src/pyze/api/kamereon.py
+++ b/src/pyze/api/kamereon.py
@@ -128,7 +128,14 @@ class Kamereon(CachingAPIObject):
 
         token = response_body.get('accessToken')
         if token:
-            decoded = jwt.decode(token, options={'verify_signature': False, 'verify_aud': False})
+            decoded = jwt.decode(
+                token,
+                options={
+                    'verify_signature': False,
+                    'verify_aud': False,
+                    'verify_nbf': False
+                }
+            )
             self._credentials['kamereon'] = (token, decoded['exp'])
             self._clear_all_caches()
             return token


### PR DESCRIPTION
Clock skew or whatever means that we can sometimes receive a token before it's valid for use. By the time we actually use it, it's probably going to be fine.

Resolves #52.