### PR TITLE
Add ability to bypass disk storage of Credential Store

### DIFF
--- a/src/pyze/api/__init__.py
+++ b/src/pyze/api/__init__.py
@@ -1,4 +1,4 @@
-from .credentials import CredentialStore, requires_credentials
+from .credentials import CredentialStore
 from .gigya import Gigya
 from .kamereon import Kamereon, Vehicle, ChargeState, PlugState
 from .schedule import ChargeSchedule, ScheduledCharge, ChargeMode

--- a/src/pyze/api/credentials.py
+++ b/src/pyze/api/credentials.py
@@ -94,7 +94,6 @@ class CredentialStore(object):
                     raise MissingCredentialException(name)
 
 
-
 Credential = namedtuple(
     'Credential',
     [

--- a/src/pyze/api/credentials.py
+++ b/src/pyze/api/credentials.py
@@ -17,18 +17,6 @@ class MissingCredentialException(Exception):
     pass
 
 
-def requires_credentials(*names):
-    def _requires_credentials(func):
-        def inner(*args, **kwargs):
-            for name in names:
-                if name not in CredentialStore():
-                    raise MissingCredentialException(name)
-            return func(*args, **kwargs)
-
-        return inner
-    return _requires_credentials
-
-
 def init_store():
     new_store = {}
     try:
@@ -99,6 +87,12 @@ class CredentialStore(object):
 
             if 'KAMEREON_API_KEY' in os.environ:
                 self.store('kamereon-api-key', os.environ['KAMEREON_API_KEY'], None)
+
+        def requires(self, *names):
+            for name in names:
+                if name not in self._store:
+                    raise MissingCredentialException(name)
+
 
 
 Credential = namedtuple(

--- a/src/pyze/api/credentials.py
+++ b/src/pyze/api/credentials.py
@@ -5,8 +5,6 @@ import simplejson
 import time
 
 
-TOKEN_STORE = os.environ.get('PYZE_TOKEN_STORE', os.path.expanduser('~/.credentials/pyze.json'))
-
 PERMANENT_KEYS = [
     'gigya-api-key',
     'kamereon-api-key'
@@ -17,81 +15,87 @@ class MissingCredentialException(Exception):
     pass
 
 
-def init_store():
-    new_store = {}
-    try:
-        with open(TOKEN_STORE, 'r') as token_store:
-            stored = simplejson.load(token_store)
+class CredentialStore(object):
+    def __init__(self):
+        self._store = {}
+        self._add_api_keys_from_env()
 
-            for key, value in stored.items():
-                new_store[key] = Credential(value['token'], value['expiry'])
-    except Exception:
+    def __getitem__(self, name):
+        if name in self._store:
+            cred = self._store[name]
+            if not cred.expiry or cred.expiry > time.time():
+                return cred.token
+        raise KeyError(name)
+
+    def __setitem__(self, name, value):
+        return self.store(name, *value)
+
+    def store(self, name, token, expiry):
+        if not isinstance(name, str):
+            raise RuntimeError('Credential name must be a string')
+        if not isinstance(token, str):
+            raise RuntimeError('Credential value must be a string')
+        self._store[name] = Credential(token, expiry)
+        self._write()
+
+    def _write(self):
         pass
 
-    return new_store
+    def __contains__(self, name):
+        try:
+            return self[name] is not None
+        except KeyError:
+            return False
+
+    def clear(self):
+        for k in list(self._store.keys()):
+            if k not in PERMANENT_KEYS:
+                del self._store[k]
+        self._write()
+
+    def _add_api_keys_from_env(self):
+        if 'GIGYA_API_KEY' in os.environ:
+            self.store('gigya-api-key', os.environ['GIGYA_API_KEY'], None)
+
+        if 'KAMEREON_API_KEY' in os.environ:
+            self.store('kamereon-api-key', os.environ['KAMEREON_API_KEY'], None)
+
+    def requires(self, *names):
+        for name in names:
+            if name not in self._store:
+                raise MissingCredentialException(name)
 
 
-class CredentialStore(object):
+class FileCredentialStore(CredentialStore):
+    def __init__(self, store_location):
+        self._store_location = store_location
+        self._store = {}
+        try:
+            with open(self._store_location, 'r') as token_store:
+                stored = simplejson.load(token_store)
+
+                for key, value in stored.items():
+                    self._store[key] = Credential(value['token'], value['expiry'])
+        except Exception:
+            pass
+        self._add_api_keys_from_env()
+
+    def _write(self):
+        dirname = os.path.dirname(self._store_location)
+        if not os.path.isdir(dirname):
+            os.makedirs(dirname)
+        with open(self._store_location, 'w') as token_store:
+            simplejson.dump(self._store, token_store)
+
+
+class DefaultCredentialStore(object):
     __instance = None
 
     def __new__(cls):
-        if CredentialStore.__instance is None:
-            CredentialStore.__instance = CredentialStore._CredentialStore()
-        return CredentialStore.__instance
-
-    class _CredentialStore(object):
-        def __init__(self):
-            self._store = init_store()
-            self._add_api_keys_from_env()
-
-        def __getitem__(self, name):
-            if name in self._store:
-                cred = self._store[name]
-                if not cred.expiry or cred.expiry > time.time():
-                    return cred.token
-            raise KeyError(name)
-
-        def __setitem__(self, name, value):
-            return self.store(name, *value)
-
-        def store(self, name, token, expiry):
-            if not isinstance(name, str):
-                raise RuntimeError('Credential name must be a string')
-            if not isinstance(token, str):
-                raise RuntimeError('Credential value must be a string')
-            self._store[name] = Credential(token, expiry)
-            self._write()
-
-        def _write(self):
-            dirname = os.path.dirname(TOKEN_STORE)
-            if not os.path.isdir(dirname):
-                os.makedirs(dirname)
-            with open(TOKEN_STORE, 'w') as token_store:
-                simplejson.dump(self._store, token_store)
-
-        def __contains__(self, name):
-            try:
-                return self[name] is not None
-            except KeyError:
-                return False
-
-        def clear(self):
-            for k in list(self._store.keys()):
-                if k not in PERMANENT_KEYS:
-                    del self._store[k]
-            self._write()
-
-        def _add_api_keys_from_env(self):
-            if 'GIGYA_API_KEY' in os.environ:
-                self.store('gigya-api-key', os.environ['GIGYA_API_KEY'], None)
-
-            if 'KAMEREON_API_KEY' in os.environ:
-                self.store('kamereon-api-key', os.environ['KAMEREON_API_KEY'], None)
-
-        def requires(self, *names):
-            for name in names:
-                if name not in self._store:
-                    raise MissingCredentialException(name)
+        if DefaultCredentialStore.__instance is None:
+            default_store_location = os.environ.get('PYZE_TOKEN_STORE', os.path.expanduser('~/.credentials/pyze.json'))
+            DefaultCredentialStore.__instance = FileCredentialStore(default_store_location)
+        return DefaultCredentialStore.__instance
 
 
 Credential = namedtuple(

--- a/src/pyze/api/gigya.py
+++ b/src/pyze/api/gigya.py
@@ -1,4 +1,4 @@
-from .credentials import CredentialStore
+from .credentials import DefaultCredentialStore
 from functools import lru_cache
 
 import jwt
@@ -18,7 +18,7 @@ class Gigya(object):
         credentials=None,
         root_url=DEFAULT_ROOT_URL,
     ):
-        self._credentials = credentials or CredentialStore()
+        self._credentials = credentials or DefaultCredentialStore()
         self._session = requests.Session()
         self._root_url = root_url
         if api_key:

--- a/src/pyze/api/gigya.py
+++ b/src/pyze/api/gigya.py
@@ -1,4 +1,4 @@
-from .credentials import requires_credentials, CredentialStore
+from .credentials import CredentialStore
 from functools import lru_cache
 
 import jwt
@@ -62,8 +62,8 @@ class Gigya(object):
             )
 
     @lru_cache(maxsize=1)
-    @requires_credentials('gigya')
     def account_info(self):
+        self._credentials.requires('gigya')
         response = self._session.post(
             self._root_url + '/accounts.getAccountInfo',
             {
@@ -88,8 +88,8 @@ class Gigya(object):
             )
         )
 
-    @requires_credentials('gigya')
     def get_jwt_token(self):
+        self._credentials.requires('gigya')
 
         if 'gigya-token' in self._credentials:
             return self._credentials['gigya-token']

--- a/src/pyze/api/kamereon.py
+++ b/src/pyze/api/kamereon.py
@@ -1,4 +1,4 @@
-from .credentials import CredentialStore
+from .credentials import DefaultCredentialStore
 from .gigya import Gigya
 from .schedule import ChargeSchedules, ChargeMode
 from collections import namedtuple
@@ -42,7 +42,7 @@ class Kamereon(CachingAPIObject):
     ):
 
         self._root_url = root_url
-        self._credentials = credentials or CredentialStore()
+        self._credentials = credentials or DefaultCredentialStore()
         self._country = country
         self._gigya = gigya or Gigya(credentials=self._credentials)
         self._session = requests.Session()

--- a/src/pyze/api/kamereon.py
+++ b/src/pyze/api/kamereon.py
@@ -1,4 +1,4 @@
-from .credentials import CredentialStore, requires_credentials, TOKEN_STORE
+from .credentials import CredentialStore
 from .gigya import Gigya
 from .schedule import ChargeSchedules, ChargeMode
 from collections import namedtuple
@@ -82,8 +82,8 @@ class Kamereon(CachingAPIObject):
         self._credentials['kamereon-account'] = (account['accountId'], None)
         return account['accountId']
 
-    @requires_credentials('gigya', 'gigya-person-id', 'kamereon-api-key')
     def get_accounts(self):
+        self._credentials.requires('gigya', 'gigya-person-id', 'kamereon-api-key')
         response = self._session.get(
             '{}/commerce/v1/persons/{}?country={}'.format(
                 self._root_url,
@@ -105,8 +105,8 @@ class Kamereon(CachingAPIObject):
     def set_account_id(self, account_id):
         self._credentials['kamereon-account'] = (account_id, None)
 
-    @requires_credentials('gigya', 'gigya-person-id', 'kamereon-api-key')
     def get_token(self):
+        self._credentials.requires('gigya', 'gigya-person-id', 'kamereon-api-key')
         if 'kamereon' in self._credentials:
             return self._credentials['kamereon']
 
@@ -147,8 +147,8 @@ class Kamereon(CachingAPIObject):
             )
 
     @lru_cache(maxsize=1)
-    @requires_credentials('kamereon-api-key')
     def get_vehicles(self):
+        self._credentials.requires('kamereon-api-key')
         response = self._session.get(
             '{}/commerce/v1/accounts/{}/vehicles?country={}'.format(
                 self._root_url,
@@ -175,8 +175,8 @@ class Vehicle(object):
         self._kamereon = kamereon or Kamereon()
         self._root_url = self._kamereon._root_url
 
-    @requires_credentials('kamereon-api-key')
     def _request(self, method, endpoint, **kwargs):
+        self._kamereon._credentials.requires('kamereon-api-key')
         return self._kamereon._session.request(
             method,
             endpoint,


### PR DESCRIPTION
When used in API mode and inside a long running service, it might be necessary to have multiple Credential Store in parallel.
In this case, the Credential Store shouldn't be storing anything on the disk, and keep everything in memory.

This PR splits the CredentialStore class into three separate classes:
- CredentialStore => no longer writes to disk
- FileCredentialStore => inherits CredentialStore and add storage to disk
- DefaultCredentialStore => replaces the old "static" CredentialStore for use within the pyze client