### PR TITLE
Add ability to bypass disk storage of CredentialStore

### DIFF
--- a/src/pyze/api/__init__.py
+++ b/src/pyze/api/__init__.py
@@ -1,4 +1,4 @@
-from .credentials import CredentialStore, requires_credentials
+from .credentials import CredentialStore, FileCredentialStore, BasicCredentialStore
 from .gigya import Gigya
 from .kamereon import Kamereon, Vehicle, ChargeState, PlugState
 from .schedule import ChargeSchedule, ScheduledCharge, ChargeMode

--- a/src/pyze/api/credentials.py
+++ b/src/pyze/api/credentials.py
@@ -5,8 +5,6 @@ import simplejson
 import time
 
 
-TOKEN_STORE = os.environ.get('PYZE_TOKEN_STORE', os.path.expanduser('~/.credentials/pyze.json'))
-
 PERMANENT_KEYS = [
     'gigya-api-key',
     'kamereon-api-key'
@@ -29,76 +27,87 @@ def requires_credentials(*names):
     return _requires_credentials
 
 
-def init_store():
-    new_store = {}
-    try:
-        with open(TOKEN_STORE, 'r') as token_store:
-            stored = simplejson.load(token_store)
-
-            for key, value in stored.items():
-                new_store[key] = Credential(value['token'], value['expiry'])
-    except Exception:
-        pass
-
-    return new_store
-
-
 class CredentialStore(object):
     __instance = None
 
     def __new__(cls):
         if CredentialStore.__instance is None:
-            CredentialStore.__instance = CredentialStore._CredentialStore()
+            default_store_location = os.environ.get('PYZE_TOKEN_STORE', os.path.expanduser('~/.credentials/pyze.json'))
+            CredentialStore.__instance = FileCredentialStore(default_store_location)
         return CredentialStore.__instance
 
-    class _CredentialStore(object):
-        def __init__(self):
-            self._store = init_store()
-            self._add_api_keys_from_env()
 
-        def __getitem__(self, name):
-            if name in self._store:
-                cred = self._store[name]
-                if not cred.expiry or cred.expiry > time.time():
-                    return cred.token
-            raise KeyError(name)
+class BasicCredentialStore(object):
+    def __init__(self):
+        self._store = {}
+        self._add_api_keys_from_env()
 
-        def __setitem__(self, name, value):
-            return self.store(name, *value)
+    def __getitem__(self, name):
+        if name in self._store:
+            cred = self._store[name]
+            if not cred.expiry or cred.expiry > time.time():
+                return cred.token
+        raise KeyError(name)
 
-        def store(self, name, token, expiry):
-            if not isinstance(name, str):
-                raise RuntimeError('Credential name must be a string')
-            if not isinstance(token, str):
-                raise RuntimeError('Credential value must be a string')
-            self._store[name] = Credential(token, expiry)
-            self._write()
+    def __setitem__(self, name, value):
+        return self.store(name, *value)
 
-        def _write(self):
-            dirname = os.path.dirname(TOKEN_STORE)
-            if not os.path.isdir(dirname):
-                os.makedirs(dirname)
-            with open(TOKEN_STORE, 'w') as token_store:
-                simplejson.dump(self._store, token_store)
+    def store(self, name, token, expiry):
+        if not isinstance(name, str):
+            raise RuntimeError('Credential name must be a string')
+        if not isinstance(token, str):
+            raise RuntimeError('Credential value must be a string')
+        self._store[name] = Credential(token, expiry)
+        self._write()
 
-        def __contains__(self, name):
-            try:
-                return self[name] is not None
-            except KeyError:
-                return False
+    def _write(self):
+        pass
 
-        def clear(self):
-            for k in list(self._store.keys()):
-                if k not in PERMANENT_KEYS:
-                    del self._store[k]
-            self._write()
+    def __contains__(self, name):
+        try:
+            return self[name] is not None
+        except KeyError:
+            return False
 
-        def _add_api_keys_from_env(self):
-            if 'GIGYA_API_KEY' in os.environ:
-                self.store('gigya-api-key', os.environ['GIGYA_API_KEY'], None)
+    def clear(self):
+        for k in list(self._store.keys()):
+            if k not in PERMANENT_KEYS:
+                del self._store[k]
+        self._write()
 
-            if 'KAMEREON_API_KEY' in os.environ:
-                self.store('kamereon-api-key', os.environ['KAMEREON_API_KEY'], None)
+    def _add_api_keys_from_env(self):
+        if 'GIGYA_API_KEY' in os.environ:
+            self.store('gigya-api-key', os.environ['GIGYA_API_KEY'], None)
+
+        if 'KAMEREON_API_KEY' in os.environ:
+            self.store('kamereon-api-key', os.environ['KAMEREON_API_KEY'], None)
+
+    def requires(self, *names):
+        for name in names:
+            if name not in self._store:
+                raise MissingCredentialException(name)
+
+
+class FileCredentialStore(BasicCredentialStore):
+    def __init__(self, store_location):
+        self._store_location = store_location
+        self._store = {}
+        try:
+            with open(self._store_location, 'r') as token_store:
+                stored = simplejson.load(token_store)
+
+                for key, value in stored.items():
+                    self._store[key] = Credential(value['token'], value['expiry'])
+        except Exception:
+            pass
+        self._add_api_keys_from_env()
+
+    def _write(self):
+        dirname = os.path.dirname(self._store_location)
+        if not os.path.isdir(dirname):
+            os.makedirs(dirname)
+        with open(self._store_location, 'w') as token_store:
+            simplejson.dump(self._store, token_store)
 
 
 Credential = namedtuple(

--- a/src/pyze/api/kamereon.py
+++ b/src/pyze/api/kamereon.py
@@ -1,4 +1,4 @@
-from .credentials import CredentialStore, requires_credentials, TOKEN_STORE
+from .credentials import CredentialStore, requires_credentials
 from .gigya import Gigya
 from .schedule import ChargeSchedules, ChargeMode
 from collections import namedtuple


### PR DESCRIPTION
When used in API mode and inside a long running service, it might be necessary to have multiple Credential Store in parallel.
In this case, the Credential Store shouldn't be storing anything on the disk, and keep everything in memory.

This PR splits the CredentialStore class into three separate classes:
- BasicCredentialStore => new base class which handles most old methods but no longer writes to disk
- FileCredentialStore => inherits BasicCredentialStore and adds storage to disk
- CredentialStore => Singleton of FileCredentialStore with the default file path (PYZE_TOKEN_STORE environment variable or ~/.credentials/pyze.json)

_Note: this PR is very similar to PR 62 but without the "leaks" from PR 61. This forced me to keep the old naming convention of CredentialStore() being a Singleton._