### PR TITLE
Add new charge mode

### DIFF
--- a/src/pyze/api/schedule.py
+++ b/src/pyze/api/schedule.py
@@ -31,6 +31,7 @@ MINUTES_IN_DAY = 60 * 24
 
 
 class ChargeMode(Enum):
+    always = 'Always'
     always_charging = 'Always charge'
     schedule_mode = 'Scheduled charge'
 


### PR DESCRIPTION
Hello,

My ZE50 returns 'always' as charge mode. it's a suggestion to add.
`DEBUG:pyze.api.kamereon:Received Kamereon vehicle response: {"data":{"type":"Car","id":"XX","attributes":{"chargeMode":"always"}}}`


May be it's better to returns 'Always charging' as the other attribute ?

I haven't tested the schedule mode, i don't if it is different than 'schedule_mode' attribute of the Enum