### PR TITLE
Removed duplicated method

### DIFF
--- a/src/pyze/api/kamereon.py
+++ b/src/pyze/api/kamereon.py
@@ -213,9 +213,6 @@ class Vehicle(object):
         return self._get('lock-status')
 
     # Not implemented server-side for most vehicles
-    def location(self):
-        return self._get('location')
-
     def charge_schedules(self):
         return ChargeSchedules(
             self._get('charging-settings')


### PR DESCRIPTION
The `location()` method in the `Vehicle` class as duplicated; removed the duplicated version under the "not implemented" section.